### PR TITLE
방문 식당 수정 기능 및 VisitModal 컴포넌트 추가

### DIFF
--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/controller/UserRestaurantVisitController.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/controller/UserRestaurantVisitController.java
@@ -36,6 +36,14 @@ public class UserRestaurantVisitController {
         return ResponseEntity.ok(BaseResponse.success());
     }
 
+    @PatchMapping("/visited-restaurants/{id}")
+    public ResponseEntity<BaseResponse<Void>> updateVisitedRestaurant(@AuthenticationPrincipal User user,
+                                                                      @RequestBody UserRestaurantVisitRequestDto request,
+                                                                      @PathVariable Long id) {
+        visitService.updateVisitedRestaurant(user, request, id);
+        return ResponseEntity.ok(BaseResponse.success());
+    }
+
     @Transactional
     @DeleteMapping("/visited-restaurants/{id}")
     public ResponseEntity<BaseResponse<Void>> deleteVisitedRestaurant(@AuthenticationPrincipal User user, @PathVariable Long id) {

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/exception/UserExceptionType.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/exception/UserExceptionType.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserExceptionType implements BaseExceptionType {
 
-    ALREADY_VISITED_RESTAURANT(1, 400, "이미 저장된 정보입니다.");
+    ALREADY_VISITED_RESTAURANT(1, 400, "이미 저장된 정보입니다."),
+    VISIT_NOT_FOUND(2, 404, "No visit found."),
+    FORBIDDEN(3, 403, "Forbidden");
 
     private final int code;
     private final int httpStatusCode;

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/service/UserRestaurantVisitService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/service/UserRestaurantVisitService.java
@@ -11,6 +11,7 @@ import com.kong.kong_dic.domain.user.entity.UserRestaurantVisit;
 import com.kong.kong_dic.domain.user.exception.UserExceptionType;
 import com.kong.kong_dic.domain.user.repository.UserRestaurantVisitRepository;
 import com.kong.kong_dic.global.exception.BaseException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -59,5 +60,20 @@ public class UserRestaurantVisitService {
 
     public void deleteVisitedRestaurant(User user, Long id) {
         visitRepository.deleteByIdAndUserId(id, user.getId());
+    }
+
+    @Transactional
+    public void updateVisitedRestaurant(User user, UserRestaurantVisitRequestDto request, Long id) {
+        UserRestaurantVisit visit = visitRepository.findById(id)
+                .orElseThrow(() -> new BaseException(UserExceptionType.VISIT_NOT_FOUND));
+
+        if (!visit.getUser().getId().equals(user.getId())) {
+            throw new BaseException(UserExceptionType.FORBIDDEN);
+        }
+
+        if (request.getRating() != null)
+            visit.setRating(request.getRating());
+        if (request.getMemo() != null)
+            visit.setMemo(request.getMemo());
     }
 }

--- a/kongguksu-front/src/components/VisitModal.js
+++ b/kongguksu-front/src/components/VisitModal.js
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from "react";
+
+const VisitModal = ({ editingVisit, onChange, onClose, onSave }) => {
+  // editingVisit 없으면 기본값으로 초기화해서 훅 호출 보장
+  const [userRating, setUserRating] = useState(editingVisit?.rating || 0);
+
+  // editingVisit이 바뀔 때마다 userRating 초기화
+  useEffect(() => {
+    setUserRating(editingVisit?.rating || 0);
+  }, [editingVisit]);
+
+  // userRating 변경 시 onChange 호출
+  useEffect(() => {
+    if (editingVisit) {
+      onChange({ ...editingVisit, rating: userRating });
+    }
+  }, [userRating]);
+
+  // editingVisit 없으면 모달 안 띄움
+  if (!editingVisit) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl p-6 w-96 shadow-lg">
+        <h2 className="text-xl font-bold mb-4 text-[#5C5C5C]">✏️ 수정하기</h2>
+
+        <label className="block mb-2 text-sm">방문일</label>
+        <input
+          type="date"
+          className="w-full border p-2 rounded mb-4"
+          value={editingVisit.visitedDate || ''}
+          onChange={e => onChange({ ...editingVisit, visitedDate: e.target.value })}
+        />
+
+        <label className="block mb-2 text-sm">별점</label>
+        <div className="mb-4 text-center">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <span
+              key={star}
+              className={`text-3xl cursor-pointer ${
+                star <= userRating ? "text-yellow-400" : "text-gray-300"
+              }`}
+              onClick={() => setUserRating(star)}
+            >
+              ★
+            </span>
+          ))}
+        </div>
+
+        <label className="block mb-2 text-sm">메모</label>
+        <textarea
+          className="w-full border p-2 rounded mb-4"
+          value={editingVisit.memo || ''}
+          onChange={e => onChange({ ...editingVisit, memo: e.target.value })}
+        />
+
+        <div className="flex justify-between">
+          <button className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400" onClick={onClose}>
+            취소
+          </button>
+          <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" onClick={onSave}>
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VisitModal;

--- a/kongguksu-front/src/pages/MyDictionary.js
+++ b/kongguksu-front/src/pages/MyDictionary.js
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 import { Link, useNavigate } from "react-router-dom";
+import VisitModal from "../components/VisitModal";
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080';
 const ITEMS_PER_PAGE = 10;
@@ -13,6 +14,9 @@ const MyDictionary = () => {
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const [error, setError] = useState(null);
+  const [editingVisit, setEditingVisit] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
   const navigate = useNavigate();
 
   const getAuthHeader = useCallback(() => {
@@ -31,7 +35,7 @@ const MyDictionary = () => {
     try {
       const headers = getAuthHeader();
       const url = `${API_BASE_URL}/visited-restaurants?page=${pageNumber}&size=${ITEMS_PER_PAGE}`;
-      
+
       const response = await axios.get(url, { headers });
 
       if (response.data.code === 0 && Array.isArray(response.data.data)) {
@@ -41,7 +45,7 @@ const MyDictionary = () => {
           const filteredNewItems = newItems.filter(item => !existingIds.has(item.id));
           return [...prevItems, ...filteredNewItems];
         });
-        setHasMore(newItems.length === ITEMS_PER_PAGE); 
+        setHasMore(newItems.length === ITEMS_PER_PAGE);
       } else {
         setError(response.data.message || "데이터를 불러오는데 실패했습니다.");
         setHasMore(false);
@@ -64,13 +68,13 @@ const MyDictionary = () => {
     }
   }, [getAuthHeader, navigate]);
 
-  // ✅ 삭제 핸들러 함수 추가
+  // 삭제 핸들러 함수 추가
   const handleDeleteVisit = useCallback(async (visitId, restaurantName) => {
     if (window.confirm(`"${restaurantName}" 식당을 나의 사전에서 삭제할까요?`)) {
       try {
         const headers = getAuthHeader();
         const url = `${API_BASE_URL}/visited-restaurants/${visitId}`; // API 엔드포인트: /visited-restaurants/{id}
-        
+
         const response = await axios.delete(url, { headers });
 
         if (response.data.code === 0) {
@@ -103,12 +107,12 @@ const MyDictionary = () => {
     const token = localStorage.getItem('token');
     if (!token) {
       navigate('/login');
-      return; 
+      return;
     }
     setLoading(true);
-    setPage(0); 
-    setHasMore(true); 
-    setVisitedRestaurants([]); 
+    setPage(0);
+    setHasMore(true);
+    setVisitedRestaurants([]);
     fetchVisitedRestaurants(0);
   }, [fetchVisitedRestaurants, navigate]);
 
@@ -179,55 +183,98 @@ const MyDictionary = () => {
               &times; {/* HTML 엔티티로 'x' 표시 */}
             </button>
 
+            {/* 수정 버튼 */}
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setEditingVisit(visit); // 수정 대상 설정
+                setShowModal(true);     // 모달 열기
+              }}
+              className="absolute top-2 right-10 text-gray-500 hover:text-blue-500 text-lg font-bold"
+              aria-label="수정"
+            >
+              ✏️
+            </button>
+
+<VisitModal
+  editingVisit={editingVisit}
+  onChange={setEditingVisit}
+  onClose={() => setShowModal(false)}
+  onSave={async () => {
+    try {
+      const headers = getAuthHeader();
+      const url = `${API_BASE_URL}/visited-restaurants/${editingVisit.id}`;
+      const payload = {
+        visitedDate: editingVisit.visitedDate,
+        rating: editingVisit.rating,
+        memo: editingVisit.memo,
+      };
+      const response = await axios.patch(url, payload, { headers });
+      if (response.data.code === 0) {
+        alert("수정이 완료되었습니다.");
+        // 목록에서 수정된 방문 기록 반영
+        setVisitedRestaurants(prev =>
+          prev.map(v => (v.id === editingVisit.id ? editingVisit : v))
+        );
+        setShowModal(false);
+      } else {
+        alert("수정 실패: " + response.data.message);
+      }
+    } catch (err) {
+      alert("수정 중 오류 발생: " + err.message);
+    }
+  }}
+/>
             {/* 나머지 내용은 Link로 감싸서 상세 페이지 이동 */}
             <Link to={`/restaurant/${visit.restaurant.id}`} className="block">
-                <p className="font-bold text-lg">{visit.restaurant.name}</p>
-                <p className="text-sm text-gray-600">{visit.restaurant.address}</p>
-                
-                {visit.restaurant.distance != null && visit.restaurant.distance !== -1 && (
-                    <p className="text-sm">거리: {visit.restaurant.distance?.toFixed(1)}km</p>
-                )}
+              <p className="font-bold text-lg">{visit.restaurant.name}</p>
+              <p className="text-sm text-gray-600">{visit.restaurant.address}</p>
 
-                <p className="text-sm mt-1">
-                    콩 종류:{" "}
-                    {visit.restaurant.beanTypes && visit.restaurant.beanTypes.length > 0 ? (
-                        visit.restaurant.beanTypes.map((type, index) => (
-                            <span key={type}>
-                                {type === "SOY_BEAN" ? "백태콩" : type === "BLACK_BEAN" ? "검은콩" : type}
-                                {index < visit.restaurant.beanTypes.length - 1 ? ", " : ""}
-                            </span>
-                        ))
-                    ) : (
-                        <span>정보 없음</span>
-                    )}
-                </p>
+              {visit.restaurant.distance != null && visit.restaurant.distance !== -1 && (
+                <p className="text-sm">거리: {visit.restaurant.distance?.toFixed(1)}km</p>
+              )}
+
+              <p className="text-sm mt-1">
+                콩 종류:{" "}
+                {visit.restaurant.beanTypes && visit.restaurant.beanTypes.length > 0 ? (
+                  visit.restaurant.beanTypes.map((type, index) => (
+                    <span key={type}>
+                      {type === "SOY_BEAN" ? "백태콩" : type === "BLACK_BEAN" ? "검은콩" : type}
+                      {index < visit.restaurant.beanTypes.length - 1 ? ", " : ""}
+                    </span>
+                  ))
+                ) : (
+                  <span>정보 없음</span>
+                )}
+              </p>
+              <p className="text-sm">
+                판매 기간:{" "}
+                {visit.restaurant.servesAllYear
+                  ? "사계절 판매"
+                  : visit.restaurant.startMonth && visit.restaurant.endMonth
+                    ? `${visit.restaurant.startMonth}월 ~ ${visit.restaurant.endMonth}월`
+                    : "정보 없음"}
+              </p>
+              {visit.restaurant.prices && visit.restaurant.prices.length > 0 && (
                 <p className="text-sm">
-                    판매 기간:{" "}
-                    {visit.restaurant.servesAllYear
-                        ? "사계절 판매"
-                        : visit.restaurant.startMonth && visit.restaurant.endMonth
-                            ? `${visit.restaurant.startMonth}월 ~ ${visit.restaurant.endMonth}월`
-                            : "정보 없음"}
+                  가격:{" "}
+                  {visit.restaurant.prices.map((bp, idx) => (
+                    <span key={bp.beanType}>
+                      {bp.beanType === "SOY_BEAN" ? "백태콩" : bp.beanType === "BLACK_BEAN" ? "검은콩" : bp.beanType}: {bp.price}원
+                      {idx < visit.restaurant.prices.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
                 </p>
-                {visit.restaurant.prices && visit.restaurant.prices.length > 0 && (
-                    <p className="text-sm">
-                        가격:{" "}
-                        {visit.restaurant.prices.map((bp, idx) => (
-                            <span key={bp.beanType}>
-                                {bp.beanType === "SOY_BEAN" ? "백태콩" : bp.beanType === "BLACK_BEAN" ? "검은콩" : bp.beanType}: {bp.price}원
-                                {idx < visit.restaurant.prices.length - 1 ? ", " : ""}
-                            </span>
-                        ))}
-                    </p>
-                )}
+              )}
 
-                <div className="mt-2 text-sm text-gray-700 border-t border-gray-200 pt-2">
-                    {visit.visitDate && <p>방문일: {visit.visitDate}</p>}
-                    {visit.rating != null && (
-                        <p>별점: {"⭐".repeat(visit.rating) + "☆".repeat(5 - visit.rating)}</p>
-                    )}
-                    {visit.memo && <p>메모: {visit.memo}</p>}
-                </div>
+              <div className="mt-2 text-sm text-gray-700 border-t border-gray-200 pt-2">
+                {visit.visitedDate && <p>방문일: {visit.visitedDate}</p>}
+                {visit.rating != null && (
+                  <p>별점: {"⭐".repeat(visit.rating) + "☆".repeat(5 - visit.rating)}</p>
+                )}
+                {visit.memo && <p>메모: {visit.memo}</p>}
+              </div>
             </Link>
           </div>
         ))}
@@ -240,5 +287,6 @@ const MyDictionary = () => {
     </div>
   );
 };
+
 
 export default MyDictionary;


### PR DESCRIPTION
사용자가 자신의 방문 기록을 수정할 수 있도록 백엔드 API를 구현하고,
프론트엔드에서는 VisitModal 컴포넌트를 통해 방문일, 별점, 메모를 수정할 수 있는 UI를 추가했습니다.

또한 별점을 숫자가 아닌 클릭 가능한 ★ UI로 구현하여 사용자 경험을 개선했습니다.

🔧 변경사항 요약 (Changes):
* 사용자가 본인의 방문 기록을 수정할 수 있는 백엔드 API 추가
    * rating, memo가 null이 아닌 경우에만 갱신
    * 본인 소유가 아닐 경우 FORBIDDEN 예외 발생

* VisitModal 컴포넌트 신규 구현
    * 방문일, 별점, 메모 입력 가능
    * 별점은 클릭 가능한 ★ UI로 구현
    * 저장 및 취소 버튼 포함
    * editingVisit 상태 변경 시 별점 동기화 처리
