### PR TITLE
fix: 검색 후 지도 줌/드래그 불가 문제 해결

### DIFF
--- a/kongguksu-front/src/components/RestaurantSubmissionForm.js
+++ b/kongguksu-front/src/components/RestaurantSubmissionForm.js
@@ -46,6 +46,8 @@ const RestaurantSubmissionForm = () => {
         const options = {
           center: new kakao.maps.LatLng(37.5665, 126.9780), // 서울 중심
           level: 5,
+          draggable: true, // 드래그 허용
+          scrollwheel: true, // 마우스 휠로 확대/축소 허용
         };
         const mapInstance = new kakao.maps.Map(container, options);
         setMap(mapInstance);
@@ -126,6 +128,9 @@ const RestaurantSubmissionForm = () => {
 
       setMarkers(newMarkers);
       map.setBounds(bounds);
+
+      map.setZoomable(true);
+      map.setDraggable(true);
     });
   };
 


### PR DESCRIPTION
## 🐛 문제 원인
- KakaoMap에서 검색 후 `setBounds()` 호출 시  
  내부적으로 지도 인터랙션(줌, 드래그)이 비활성화되는 현상이 발생함.  
- 그 결과, 검색 결과가 표시된 뒤 사용자가 지도를 직접 움직일 수 없었음.

---

## 🔧 수정 내용
- 검색 완료 후 `map.setZoomable(true)` 및 `map.setDraggable(true)` 호출하여  
  지도 인터랙션 복원 처리 추가.
- 초기 지도 생성 시 `draggable: true`, `scrollwheel: true` 옵션 명시하여  
  기본 인터랙션 가능 상태로 설정.
- 검색 후 사용자 경험(UX) 개선 — 결과 확인 후 바로 지도 이동 가능.

---

## ✅ 테스트 항목
- [x] 검색 후 마우스로 지도 드래그 가능  
- [x] 검색 후 마우스 휠/터치로 줌 가능  
- [x] 초기 지도 로딩 시 정상적으로 드래그 및 줌 작동    