### PR TITLE
fix: 마이페이지 '나의 사전' 수정 모달 닫힘 버그 및 렌더링 최적화

### DIFF
--- a/kongguksu-front/src/pages/MyDictionary.js
+++ b/kongguksu-front/src/pages/MyDictionary.js
@@ -197,35 +197,6 @@ const MyDictionary = () => {
               ✏️
             </button>
 
-<VisitModal
-  editingVisit={editingVisit}
-  onChange={setEditingVisit}
-  onClose={() => setShowModal(false)}
-  onSave={async () => {
-    try {
-      const headers = getAuthHeader();
-      const url = `${API_BASE_URL}/visited-restaurants/${editingVisit.id}`;
-      const payload = {
-        visitedDate: editingVisit.visitedDate,
-        rating: editingVisit.rating,
-        memo: editingVisit.memo,
-      };
-      const response = await axios.patch(url, payload, { headers });
-      if (response.data.code === 0) {
-        alert("수정이 완료되었습니다.");
-        // 목록에서 수정된 방문 기록 반영
-        setVisitedRestaurants(prev =>
-          prev.map(v => (v.id === editingVisit.id ? editingVisit : v))
-        );
-        setShowModal(false);
-      } else {
-        alert("수정 실패: " + response.data.message);
-      }
-    } catch (err) {
-      alert("수정 중 오류 발생: " + err.message);
-    }
-  }}
-/>
             {/* 나머지 내용은 Link로 감싸서 상세 페이지 이동 */}
             <Link to={`/restaurant/${visit.restaurant.id}`} className="block">
               <p className="font-bold text-lg">{visit.restaurant.name}</p>
@@ -284,6 +255,38 @@ const MyDictionary = () => {
           <p className="text-center text-gray-600 my-4">모든 식당을 불러왔습니다.</p>
         )}
       </div>
+            {showModal && editingVisit && (
+        <VisitModal
+          editingVisit={editingVisit}
+          onChange={setEditingVisit}
+          onClose={() => setShowModal(false)}
+          onSave={async () => {
+            try {
+              const headers = getAuthHeader();
+              const url = `${API_BASE_URL}/visited-restaurants/${editingVisit.id}`;
+              const payload = {
+                visitedDate: editingVisit.visitedDate,
+                rating: editingVisit.rating,
+                memo: editingVisit.memo,
+              };
+              const response = await axios.patch(url, payload, { headers });
+              
+              if (response.data.code === 0) {
+                alert("수정이 완료되었습니다.");
+                // 목록 업데이트
+                setVisitedRestaurants(prev =>
+                  prev.map(v => (v.id === editingVisit.id ? editingVisit : v))
+                );
+                setShowModal(false);
+              } else {
+                alert("수정 실패: " + response.data.message);
+              }
+            } catch (err) {
+              alert("수정 중 오류 발생: " + err.message);
+            }
+          }}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Fix: 마이페이지 '나의 사전' 수정 모달 닫힘 버그 및 렌더링 최적화

## 📝 Description
마이페이지의 '나의 사전' 탭에서 방문 기록을 수정한 후, 저장 완료 알림이 떠도 모달창이 닫히지 않는 버그를 수정했습니다.
또한, 리스트의 각 아이템마다 모달 컴포넌트가 중복 생성되던 비효율적인 구조를 개선했습니다.

## 🛠 Changes
- **`MyDictionary.js` 구조 개선**
  - `map` 반복문 내부에 존재하던 `<VisitModal />`을 제거하고, 컴포넌트 최상위 레벨(반복문 밖)로 이동시켰습니다.
  - 이제 페이지 내에 **단 하나의 모달 인스턴스**만 존재하며, 선택된 데이터(`editingVisit`)만 주입받아 렌더링하도록 최적화되었습니다.
- **버그 수정**
  - 수정 API 호출 성공(`onSave`) 후 `setShowModal(false)`가 정상적으로 호출되어 모달이 닫히도록 로직을 수정했습니다.

## ✅ Check List
- [x] '나의 사전' 목록에서 수정(✏️) 버튼 클릭 시 모달이 정상적으로 열리는지 확인
- [x] 내용 수정 후 '저장' 클릭 시 백엔드 반영 및 성공 알림(`alert`) 확인
- [x] **성공 알림 확인(확인 버튼 클릭) 후 모달이 자동으로 닫히는지 확인**
- [x] 수정된 내용(별점, 메모 등)이 리스트에 즉시 반영되는지 확인