### PR TITLE
feat: Redis ZSet 기반 실시간 조회수 집계 시스템 도입 및 관련 버그 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,16 +10,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Docker Hub 로그인 (manual)
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login \
-          -u "${{ secrets.DOCKER_USERNAME }}" \
-          --password-stdin
-#      - name: Docker Hub 로그인
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKER_USERNAME }}
-#          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: QEMU 설정
+        uses: docker/setup-qemu-action@v2
+
+      - name: Buildx 설정
+        uses: docker/setup-buildx-action@v2
+
+#      - name: Docker Hub 로그인 (manual)
+#        run: |
+#          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login \
+#          -u "${{ secrets.DOCKER_USERNAME }}" \
+#          --password-stdin
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: kong-dic application.yml 파일 생성
         run: |
           mkdir -p ./kong-dic/src/main/resources
@@ -37,6 +43,7 @@ jobs:
           file: kong-dic/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/kong-dic:latest
+          platforms: linux/amd64,linux/arm64
 
       - name: kong-dic-admin 빌드 & 푸시
         uses: docker/build-push-action@v4
@@ -45,6 +52,7 @@ jobs:
           file: kong-dic-admin/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/kong-dic-admin:latest
+          platforms: linux/amd64,linux/arm64
 
 #  deploy:
 #    needs: build-and-push

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/notification/redis/RedisStreamManager.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/notification/redis/RedisStreamManager.java
@@ -87,6 +87,12 @@ public class RedisStreamManager {
                 }
             } catch (Exception e) {
                 log.error("Redis Stream 소비 중 에러 발생", e);
+
+                // NO GROUP 에러인 경우 그룹 닷 생성
+                if (e.getMessage() != null && e.getMessage().contains("NOGROUP")) {
+                    log.info(">>> NOGROUP Error 감지, Stream group 재생성 시도");
+                    createStreamGroup(GLOBAL_STREAM_KEY, GROUP_NAME);
+                }
                 try {
                     Thread.sleep(1000); // 에러 발생 시 잠시 대기 (CPU 폭주 방지)
                 } catch (InterruptedException ie) {

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/controller/RestaurantController.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/controller/RestaurantController.java
@@ -1,12 +1,11 @@
 package com.kong.kong_dic.domain.restaurant.controller;
 
-import com.kong.kong_dic.common.response.BaseResponse;
 import com.kong.kong_dic.common.model.BeanType;
+import com.kong.kong_dic.common.response.BaseResponse;
 import com.kong.kong_dic.domain.restaurant.dto.RestaurantRankingDto;
 import com.kong.kong_dic.domain.restaurant.dto.RestaurantRequestDto;
 import com.kong.kong_dic.domain.restaurant.dto.RestaurantResponseDto;
 import com.kong.kong_dic.domain.restaurant.service.RestaurantService;
-import com.kong.kong_dic.domain.user.entity.User;
 import com.kong.kong_dic.global.annotation.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
@@ -143,8 +141,8 @@ public class RestaurantController {
      * 실시간 인기 콩국수 랭킹 조회 (TOP 10)
      */
     @GetMapping("/ranking")
-    public ResponseEntity<BaseResponse<List<RestaurantRankingDto>>> getRestaurantRanking(@RequestParam(name = "period", defaultValue = "daily") String period) {
-        return ResponseEntity.ok(BaseResponse.success(restaurantService.getTopRestaurants(period)));
+    public ResponseEntity<BaseResponse<List<RestaurantRankingDto>>> getRestaurantRankingByViewCount(@RequestParam(name = "period", defaultValue = "daily") String period) {
+        return ResponseEntity.ok(BaseResponse.success(restaurantService.getTopRestaurantsByViewCount(period)));
     }
 
     /**

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/dto/RestaurantRankingDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/dto/RestaurantRankingDto.java
@@ -16,6 +16,7 @@ public class RestaurantRankingDto {
     private String address;
     private Double averageRating;
     private Long reviewCount;
+    private Long viewCount;
     private int rank;
 
     public static RestaurantRankingDto of(Restaurant restaurant, int rank) {
@@ -25,6 +26,7 @@ public class RestaurantRankingDto {
                 .address(restaurant.getAddress())
                 .averageRating(restaurant.getAverageRating())
                 .reviewCount(restaurant.getTotalScraps())
+                .viewCount(restaurant.getViewCount())
                 .rank(rank)
                 .build();
     }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/dto/RestaurantResponseDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/dto/RestaurantResponseDto.java
@@ -25,4 +25,5 @@ public class RestaurantResponseDto {
     private Boolean isSaved;
     private Double averageRating;
     private Long totalScraps;
+    private Long viewCount;
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/entity/Restaurant.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/entity/Restaurant.java
@@ -53,6 +53,12 @@ public class Restaurant {
     @Builder.Default
     private Double averageRating = 0.0;
 
+    private Long viewCount = 0L;
+
+    public void addViewCount(Long count) {
+        this.viewCount += count;
+    }
+
     // 통계 업데이트
     public void updateStats(Long count, Double rating) {
         this.totalScraps = count;

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/scheduler/RankingScheduler.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/scheduler/RankingScheduler.java
@@ -1,10 +1,13 @@
 package com.kong.kong_dic.domain.restaurant.scheduler;
 
+import com.kong.kong_dic.domain.restaurant.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -12,8 +15,11 @@ import org.springframework.stereotype.Component;
 public class RankingScheduler {
 
     private final StringRedisTemplate redisTemplate;
+    private final RestaurantRepository restaurantRepository;
     private static final String DAILY_VIEWS_RANKING_KEY = "restaurant:ranking:views:daily";
     private static final String DAILY_VIEWS_RANKING_CACHE_KEY = "restaurant:ranking:top10_cache:daily";
+    private static final String ZSET_VIEWS_ALL_KEY = "restaurant:ranking:views";
+
     /**
      * 매일 자정(00:00:00)에 실행되는 일간 랭킹 초기화 스케줄러
      */
@@ -28,5 +34,36 @@ public class RankingScheduler {
         } catch (Exception e) {
             log.error(">> 일간 랭킹 초기화 중 오류 발생", e);
         }
+    }
+
+    @Scheduled(cron = "0 */2 * * * *", zone = "Asia/Seoul") // 5분마다
+    public void syncViewCountToDB() {
+        log.info(">> 조회수 Redis → DB 동기화 시작");
+
+        Set<String> restaurantIds = redisTemplate.opsForZSet()
+                .range(ZSET_VIEWS_ALL_KEY, 0, -1);
+
+        if (restaurantIds == null || restaurantIds.isEmpty()) {
+            log.info(">> 동기화할 조회수 데이터 없음");
+            return;
+        }
+
+        for (String idStr : restaurantIds) {
+            try {
+                Long id = Long.valueOf(idStr);
+                Double score = redisTemplate.opsForZSet()
+                        .score(ZSET_VIEWS_ALL_KEY, idStr);
+                if (score == null) continue;
+
+                restaurantRepository.findById(id).ifPresent(restaurant -> {
+                    restaurant.setViewCount(score.longValue());
+                    restaurantRepository.save(restaurant);
+                });
+            } catch (Exception e) {
+                log.error(">> 조회수 동기화 실패 - id: {}", idStr, e);
+            }
+        }
+
+        log.info(">> 조회수 DB 동기화 완료");
     }
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
@@ -172,7 +172,7 @@ public class RestaurantService {
             // 1. Redis에서 캐시된 완성본(JSON)이 있는지 먼저 확인 (Cache Hit)
             String cachedRanking = stringRedisTemplate.opsForValue().get(cacheKey);
             if (cachedRanking != null) {
-                log.info("🎯 랭킹 캐시 적중! (DB 조회 생략)");
+                log.info(">> 랭킹 캐시 존재 (DB 조회 생략)");
                 // JSON 문자열을 List<RestaurantRankingDto> 객체로 변환하여 즉시 반환
                 return objectMapper.readValue(cachedRanking, new TypeReference<List<RestaurantRankingDto>>() {});
             }
@@ -180,7 +180,7 @@ public class RestaurantService {
             log.warn("랭킹 캐시 읽기 실패. DB 조회를 진행합니다.", e);
         }
 
-        log.info("🐌 랭킹 캐시 없음. ZSet 및 DB를 조회하여 랭킹을 새로 계산합니다.");
+        log.info(">> 랭킹 캐시 없음. ZSet 및 DB를 조회하여 랭킹을 새로 계산합니다.");
 
         // 2. 캐시가 없으면(Cache Miss) 기존 로직대로 새로 계산
         Set<Object> topIdsObj = redisService.getTopRanking(zSetKey, 0, 9);
@@ -262,9 +262,17 @@ public class RestaurantService {
         Restaurant restaurant = restaurantRepository.findById(id)
                 .orElseThrow(() -> new BaseException(RestaurantExceptionType.RESTAURANT_NOT_FOUND));
 
-        // 조회수 1 증가 (Redis ZSet)
+        // 조회수 1 증가
         redisService.incrementScore(RANKING_KEY, id.toString(), 1.0);
         redisService.incrementScore(DAILY_RANKING_KEY, id.toString(), 1.0);
+
+        // 현재 Redis 실시간 점수 가져오기
+        Double totalScore = stringRedisTemplate.opsForZSet().score(RANKING_KEY, id.toString());
+        Double todayScore = stringRedisTemplate.opsForZSet().score(DAILY_RANKING_KEY, id.toString());
+        long totalView = (totalScore != null) ? totalScore.longValue() : 0L;
+        long todayView = (todayScore != null) ? todayScore.longValue() : 0L;
+
+        restaurant.setViewCount(restaurant.getViewCount() + totalView);
 
         // 로그인 한 경우, 이미 저장 여부
         boolean isSaved = false;
@@ -349,6 +357,7 @@ public class RestaurantService {
                 .distance(calculateDistance(restaurant, latitude, longitude))
                 .totalScraps(restaurant.getTotalScraps())
                 .averageRating(restaurant.getAverageRating())
+                .viewCount(restaurant.getViewCount())
                 .build();
     }
 

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
@@ -52,11 +52,25 @@ public class RestaurantService {
     private final KakaoMapUtil kakaoMapUtil;
 
     private final RedisService redisService;
-    private static final String RANKING_KEY = "restaurant:ranking:views";
-    private static final String RANKING_CACHE_KEY = "restaurant:ranking:top10_cache";
-    private static final String RATING_RANKING_CACHE_KEY = "restaurant:ranking:rating_top10_cache";
-    private static final String DAILY_RANKING_KEY = "restaurant:ranking:views:daily";
-    private static final String DAILY_RANKING_CACHE_KEY = "restaurant:ranking:top10_cache:daily";
+
+    // =========================================================
+    // 1. Redis Keys (ZSet): '조회수(Views)' 누적 전용
+    // (getRestaurantById 호출 시에만 업데이트 됨)
+    // =========================================================
+    private static final String ZSET_VIEWS_ALL_KEY = "restaurant:ranking:views";
+    private static final String ZSET_VIEWS_DAILY_KEY = "restaurant:ranking:views:daily";
+
+    // =========================================================
+    // 2. Redis Keys (String Cache): '조회수(Views)' 랭킹 결과 캐싱용
+    // =========================================================
+    private static final String CACHE_VIEWS_ALL_KEY = "restaurant:ranking:top10_cache";
+    private static final String CACHE_VIEWS_DAILY_KEY = "restaurant:ranking:top10_cache:daily";
+
+    // =========================================================
+    // 3. Redis Keys (String Cache): '별점(Rating)' 랭킹 결과 캐싱용
+    // (DB 통계 기반으로 계산 후 결과만 캐싱 됨)
+    // =========================================================
+    private static final String CACHE_RATING_ALL_KEY = "restaurant:ranking:rating_top10_cache";
 
     private static final Duration CACHE_TTL = Duration.ofMinutes(1);
 
@@ -159,11 +173,11 @@ public class RestaurantService {
         String zSetKey;
 
         if ("all".equals(period)) {
-            cacheKey = RANKING_CACHE_KEY;
-            zSetKey = RANKING_KEY;
+            cacheKey = CACHE_VIEWS_ALL_KEY;
+            zSetKey = ZSET_VIEWS_ALL_KEY;
         } else {
-            cacheKey = DAILY_RANKING_CACHE_KEY;
-            zSetKey = DAILY_RANKING_KEY;
+            cacheKey = CACHE_VIEWS_DAILY_KEY;
+            zSetKey = ZSET_VIEWS_DAILY_KEY;
         }
 
         try {
@@ -223,7 +237,7 @@ public class RestaurantService {
     public List<RestaurantRankingDto> getTopRatedRestaurants() {
         try {
             // 1. Redis에서 캐시된 완성본(JSON)이 있는지 확인 (Cache Hit)
-            String cachedRanking = stringRedisTemplate.opsForValue().get(RATING_RANKING_CACHE_KEY);
+            String cachedRanking = stringRedisTemplate.opsForValue().get(CACHE_RATING_ALL_KEY);
             if (cachedRanking != null) {
                 log.info("🎯 별점 랭킹 캐시 적중! (DB 조회 생략)");
                 return objectMapper.readValue(cachedRanking, new TypeReference<List<RestaurantRankingDto>>() {});
@@ -247,7 +261,7 @@ public class RestaurantService {
         // 4. 조회된 결과를 JSON으로 변환하여 Redis에 1분간 캐싱
         try {
             String rankingJson = objectMapper.writeValueAsString(rankingList);
-            stringRedisTemplate.opsForValue().set(RATING_RANKING_CACHE_KEY, rankingJson, CACHE_TTL);
+            stringRedisTemplate.opsForValue().set(CACHE_RATING_ALL_KEY, rankingJson, CACHE_TTL);
             log.info("💾 새 별점 랭킹 데이터 캐싱 완료 (TTL: 1분)");
         } catch (Exception e) {
             log.error("별점 랭킹 데이터 캐싱(직렬화) 실패", e);
@@ -261,12 +275,12 @@ public class RestaurantService {
                 .orElseThrow(() -> new BaseException(RestaurantExceptionType.RESTAURANT_NOT_FOUND));
 
         // 조회수 1 증가
-        redisService.incrementScore(RANKING_KEY, id.toString(), 1.0);
-        redisService.incrementScore(DAILY_RANKING_KEY, id.toString(), 1.0);
+        redisService.incrementScore(ZSET_VIEWS_ALL_KEY, id.toString(), 1.0);
+        redisService.incrementScore(ZSET_VIEWS_DAILY_KEY, id.toString(), 1.0);
 
         // 현재 Redis 실시간 점수 가져오기
-        Double totalScore = stringRedisTemplate.opsForZSet().score(RANKING_KEY, id.toString());
-        Double todayScore = stringRedisTemplate.opsForZSet().score(DAILY_RANKING_KEY, id.toString());
+        Double totalScore = stringRedisTemplate.opsForZSet().score(ZSET_VIEWS_ALL_KEY, id.toString());
+        Double todayScore = stringRedisTemplate.opsForZSet().score(ZSET_VIEWS_DAILY_KEY, id.toString());
         long totalView = (totalScore != null) ? totalScore.longValue() : 0L;
         long todayView = (todayScore != null) ? todayScore.longValue() : 0L;
 

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
@@ -64,8 +64,6 @@ public class RestaurantService {
     private final ObjectMapper objectMapper;
 
     public Page<RestaurantResponseDto> getAllRestaurants(Pageable pageable) {
-        Page<Restaurant> restaurantPage = restaurantRepository.findAll(pageable);
-
         Page<Restaurant> page = restaurantRepository.findAll(pageable);
         return page.map(restaurant -> entityToResponseDto(restaurant, null, null));
     }
@@ -272,8 +270,6 @@ public class RestaurantService {
         long totalView = (totalScore != null) ? totalScore.longValue() : 0L;
         long todayView = (todayScore != null) ? todayScore.longValue() : 0L;
 
-        restaurant.setViewCount(restaurant.getViewCount() + totalView);
-
         // 로그인 한 경우, 이미 저장 여부
         boolean isSaved = false;
         if (username != null) {
@@ -282,6 +278,7 @@ public class RestaurantService {
         }
 
         RestaurantResponseDto responseDto = entityToResponseDto(restaurant);
+        responseDto.setViewCount(restaurant.getViewCount() + totalView);
         responseDto.setIsSaved(isSaved);
         return responseDto;
     }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/restaurant/service/RestaurantService.java
@@ -168,7 +168,7 @@ public class RestaurantService {
      * @return
      */
     @Transactional
-    public List<RestaurantRankingDto> getTopRestaurants(String period) {
+    public List<RestaurantRankingDto> getTopRestaurantsByViewCount(String period) {
         String cacheKey;
         String zSetKey;
 
@@ -195,7 +195,7 @@ public class RestaurantService {
         log.info(">> 랭킹 캐시 없음. ZSet 및 DB를 조회하여 랭킹을 새로 계산합니다.");
 
         // 2. 캐시가 없으면(Cache Miss) 기존 로직대로 새로 계산
-        Set<Object> topIdsObj = redisService.getTopRanking(zSetKey, 0, 9);
+        Set<String> topIdsObj = redisService.getTopRanking(zSetKey, 0, 9);
 
         if (topIdsObj == null || topIdsObj.isEmpty()) {
             return Collections.emptyList();
@@ -222,7 +222,7 @@ public class RestaurantService {
         try {
             String rankingJson = objectMapper.writeValueAsString(rankingList);
             stringRedisTemplate.opsForValue().set(cacheKey, rankingJson, CACHE_TTL);
-            log.debug("💾 새 랭킹 데이터 캐싱 완료 (TTL: 1분)");
+            log.debug(">> 새 랭킹 데이터 캐싱 완료 (TTL: 1분)");
         } catch (JsonProcessingException e) {
             log.error("랭킹 데이터 캐싱(직렬화) 실패", e);
         }
@@ -292,7 +292,7 @@ public class RestaurantService {
         }
 
         RestaurantResponseDto responseDto = entityToResponseDto(restaurant);
-        responseDto.setViewCount(restaurant.getViewCount() + totalView);
+        responseDto.setViewCount(totalView);
         responseDto.setIsSaved(isSaved);
         return responseDto;
     }

--- a/kong-dic/src/main/java/com/kong/kong_dic/global/service/RedisService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/global/service/RedisService.java
@@ -2,6 +2,7 @@ package com.kong.kong_dic.global.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Set;
@@ -11,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedisService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     /**
      * 랭킹 점수 증가 (ZINCRBY)
@@ -26,7 +27,7 @@ public class RedisService {
      * @param end 끝 순위
      * @return Value Set (식당 ID 목록)
      */
-    public Set<Object> getTopRanking(String key, int start, int end) {
+    public Set<String> getTopRanking(String key, int start, int end) {
         // 점수가 높은 순으로 조회 (Reverse Range)
         return redisTemplate.opsForZSet().reverseRange(key, start, end);
     }

--- a/kongguksu-front/src/pages/Homepage.js
+++ b/kongguksu-front/src/pages/Homepage.js
@@ -233,8 +233,8 @@ function HomePage() {
                   <div className="text-sm font-bold text-gray-600 ml-2 whitespace-nowrap">
                     {activeTab === 'views' ? (
                       <span className="flex items-center gap-1">
-                        <span className="text-gray-400 text-xs font-normal">저장</span>
-                        {shop.reviewCount ?? shop.totalScraps ?? 0}
+                        <span className="text-gray-400 text-xs font-normal">조회</span>
+                        {shop.viewCount ?? 0}
                       </span>
                     ) : (
                       <span className="flex items-center gap-1 text-yellow-500">


### PR DESCRIPTION
## 📝 작업 배경 (Background)

식당 상세 조회 시 실시간 조회수를 반영하기 위해 Redis ZSet 기반의 조회수 집계 시스템을 도입했습니다.
기존에는 조회수 관련 필드 자체가 없었으며, Redis 직렬화 문제로 키가 올바르게 저장되지 않던 이슈도 함께 수정했습니다.
또한 조회수를 주기적으로 DB에 동기화하는 스케줄러를 추가하여 Redis 장애 시에도 데이터가 유실되지 않도록 개선했습니다.

## 🛠️ 주요 변경 내역 (Changes)

### 🎨 Frontend
* 백엔드 Redis ZSet 기반 조회수를 응답으로 반환하도록 수정한 것에 맞춰 식당 상세 화면에 `viewCount` 표시 추가

### ⚙️ Backend
* `Restaurant` 엔티티 및 관련 DTO에 `viewCount` 필드 추가, 식당 상세 조회 시 Redis ZSet을 활용하여 실시간 조회수 1 증가 로직 구현
* `getRestaurantById()` 수정: Redis ZSet 값만을 조회수로 반환하도록 변경 (기존 DB + Redis 중복 합산 문제 해결)
* `getRestaurantById()` 수정: Redis 실시간 조회수를 Entity가 아닌 DTO에 직접 합산하여 의도치 않은 DB UPDATE 쿼리 발생 방지
* `getAllRestaurants()` 수정: 불필요하게 중복 호출되던 `findAll()` 쿼리 제거
* `RedisService` 직렬화 문제 해결: `RedisTemplate<String, Object>` → `StringRedisTemplate` 교체하여 Redis 키에 Java 직렬화 prefix(`\xac\xed...`)가 붙는 문제 수정
* `getTopRanking()` 반환 타입 `Set<Object>` → `Set<String>` 변경 및 호출부 타입 수정
* Redis 랭킹 및 조회수 관련 키(Key) 변수명 명확화: ZSet 누적용(`ZSET_`) vs 캐시용(`CACHE_`) 역할 분리
* Redis Stream 소비 중 `NOGROUP` 에러 발생 시 `createStreamGroup()`을 재호출하도록 수정하여 런타임 중 그룹 유실 시 에러 로그가 무한히 쌓이는 문제 해결
* 매 N분마다 Redis ZSet의 조회수를 DB에 반영하는 `syncViewCountToDB()` 스케줄러 구현

## 🔗 관련 이슈 (Issues)
* Resolved **feat: Redis ZSet 기반 실시간 조회수 집계 시스템 도입 #21