### PR TITLE
feat: 이메일 인증 기반 비밀번호 재설정 및 이메일 등록 기능 구현

### DIFF
--- a/kong-dic/build.gradle
+++ b/kong-dic/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/controller/AuthController.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/controller/AuthController.java
@@ -4,6 +4,9 @@ import com.kong.kong_dic.common.response.BaseResponse;
 import com.kong.kong_dic.domain.auth.dto.LoginResponseDto;
 import com.kong.kong_dic.domain.auth.dto.RefreshRequestDto;
 import com.kong.kong_dic.domain.auth.dto.SignupRequestDto;
+import com.kong.kong_dic.domain.auth.dto.PasswordResetRequestDto;
+import com.kong.kong_dic.domain.auth.dto.PasswordResetConfirmDto;
+import jakarta.servlet.http.HttpServletRequest;
 import com.kong.kong_dic.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,5 +39,23 @@ public class AuthController {
     @GetMapping("/verify-token")
     public ResponseEntity<BaseResponse<Boolean>> verifyToken(@RequestParam String token) {
         return ResponseEntity.ok(BaseResponse.success(authService.verifyToken(token)));
+    }
+
+    @PostMapping("/reset-password/request")
+    public ResponseEntity<BaseResponse<Void>> requestPasswordReset(
+            @RequestBody PasswordResetRequestDto request,
+            HttpServletRequest servletRequest
+    ) throws Exception {
+        String origin = servletRequest.getHeader("Origin");
+        authService.requestPasswordReset(request, origin);
+        return ResponseEntity.ok(BaseResponse.success());
+    }
+
+    @PostMapping("/reset-password/confirm")
+    public ResponseEntity<BaseResponse<Void>> confirmPasswordReset(
+            @RequestBody PasswordResetConfirmDto request
+    ) {
+        authService.confirmPasswordReset(request);
+        return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/dto/PasswordResetConfirmDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/dto/PasswordResetConfirmDto.java
@@ -1,0 +1,10 @@
+package com.kong.kong_dic.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class PasswordResetConfirmDto {
+    private String token;
+    private String newPassword;
+}

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/dto/PasswordResetRequestDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/dto/PasswordResetRequestDto.java
@@ -4,9 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
-public class SignupRequestDto {
+public class PasswordResetRequestDto {
     private String username;
-    private String password;
-    private String nickname;
     private String email;
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/exception/AuthExceptionType.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/exception/AuthExceptionType.java
@@ -9,7 +9,11 @@ import lombok.RequiredArgsConstructor;
 public enum AuthExceptionType implements BaseExceptionType {
     USER_NOT_FOUND(1, 400, "Cannot find account. Please check entered data."),
     DUPLICATED_USERNAME(2, 400,"ID is duplicated. Please use another one."),
-    INVALID_REFRESH_TOKEN(3, 401, "Invalid refresh token. Please login again.");
+    INVALID_REFRESH_TOKEN(3, 401, "Invalid refresh token. Please login again."),
+    DUPLICATED_EMAIL(4, 400, "Email is duplicated. Please use another one."),
+    INVALID_RESET_TOKEN(5, 400, "Invalid or expired password reset token."),
+    USER_EMAIL_MISMATCH(6, 400, "Username and email do not match."),
+    INVALID_VERIFICATION_CODE(7, 400, "Invalid or expired verification code.");
 
     private final int code;
     private final int httpStatusCode;

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/service/AuthService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/auth/service/AuthService.java
@@ -3,11 +3,15 @@ package com.kong.kong_dic.domain.auth.service;
 import com.kong.kong_dic.common.exception.BaseException;
 import com.kong.kong_dic.domain.auth.dto.LoginResponseDto;
 import com.kong.kong_dic.domain.auth.dto.SignupRequestDto;
+import com.kong.kong_dic.domain.auth.dto.PasswordResetRequestDto;
+import com.kong.kong_dic.domain.auth.dto.PasswordResetConfirmDto;
 import com.kong.kong_dic.domain.auth.exception.AuthExceptionType;
 import com.kong.kong_dic.domain.user.entity.Role;
 import com.kong.kong_dic.domain.user.entity.User;
 import com.kong.kong_dic.domain.user.repository.UserRepository;
 import com.kong.kong_dic.global.jwt.JwtProvider;
+import com.kong.kong_dic.global.service.RedisService;
+import com.kong.kong_dic.global.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -25,16 +29,26 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
+    private final RedisService redisService;
+    private final EmailService emailService;
+
+    private static final String PASSWORD_RESET_TOKEN_PREFIX = "PR:";
+    private static final long PASSWORD_RESET_EXPIRATION_TIME = 15; // 15 minutes
 
     public void signup(SignupRequestDto request) throws Exception {
         if (userRepository.existsByUsername(request.getUsername())) {
             throw new BaseException(AuthExceptionType.DUPLICATED_USERNAME);
         }
 
+        if (request.getEmail() != null && userRepository.existsByEmail(request.getEmail())) {
+            throw new BaseException(AuthExceptionType.DUPLICATED_EMAIL);
+        }
+
         User newUser = User.builder()
                 .username(request.getUsername())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .nickname(request.getNickname())
+                .email(request.getEmail())
                 .role(Role.USER)
                 .build();
 
@@ -83,5 +97,41 @@ public class AuthService {
             return false;
         }
         return true;
+    }
+
+    @Transactional
+    public void requestPasswordReset(PasswordResetRequestDto request, String origin) throws Exception {
+        User user = userRepository.findByUsernameAndEmail(request.getUsername(), request.getEmail())
+                .orElseThrow(() -> new BaseException(AuthExceptionType.USER_EMAIL_MISMATCH));
+
+        String token = java.util.UUID.randomUUID().toString();
+
+        redisService.setData(
+                PASSWORD_RESET_TOKEN_PREFIX + token,
+                user.getUsername(),
+                PASSWORD_RESET_EXPIRATION_TIME,
+                java.util.concurrent.TimeUnit.MINUTES
+        );
+
+        String frontUrl = (origin != null && !origin.isEmpty()) ? origin : "http://localhost:3000";
+        String resetLink = frontUrl + "/reset-password?token=" + token;
+
+        emailService.sendPasswordResetEmail(user.getEmail(), resetLink);
+    }
+
+    @Transactional
+    public void confirmPasswordReset(PasswordResetConfirmDto request) {
+        String username = redisService.getData(PASSWORD_RESET_TOKEN_PREFIX + request.getToken());
+        if (username == null) {
+            throw new BaseException(AuthExceptionType.INVALID_RESET_TOKEN);
+        }
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BaseException(AuthExceptionType.USER_NOT_FOUND));
+
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
+
+        redisService.deleteData(PASSWORD_RESET_TOKEN_PREFIX + request.getToken());
     }
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/controller/UserController.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/controller/UserController.java
@@ -75,4 +75,28 @@ public class UserController {
     ) {
         return ResponseEntity.ok(BaseResponse.success("success", submitService.getMySubmissions(userDetails.getUsername())));
     }
+
+    /**
+     * 이메일 등록을 위한 인증번호 전송 API
+     */
+    @PostMapping("/email/verification-request")
+    public ResponseEntity<BaseResponse<Void>> sendEmailVerification(
+            @AuthUser UserDetails userDetails,
+            @RequestBody EmailVerificationRequestDto request
+    ) throws Exception {
+        userService.sendVerificationCode(userDetails.getUsername(), request);
+        return ResponseEntity.ok(BaseResponse.success());
+    }
+
+    /**
+     * 이메일 인증번호 확인 및 이메일 등록 API
+     */
+    @PostMapping("/email/verify-and-register")
+    public ResponseEntity<BaseResponse<UserProfileResponseDto>> verifyAndRegisterEmail(
+            @AuthUser UserDetails userDetails,
+            @RequestBody EmailRegisterRequestDto request
+    ) {
+        UserProfileResponseDto response = userService.verifyAndRegisterEmail(userDetails.getUsername(), request);
+        return ResponseEntity.ok(BaseResponse.success("Email verified and registered successfully.", response));
+    }
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/dto/EmailRegisterRequestDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/dto/EmailRegisterRequestDto.java
@@ -1,0 +1,10 @@
+package com.kong.kong_dic.domain.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class EmailRegisterRequestDto {
+    private String email;
+    private String code;
+}

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/dto/EmailVerificationRequestDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/dto/EmailVerificationRequestDto.java
@@ -1,0 +1,9 @@
+package com.kong.kong_dic.domain.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class EmailVerificationRequestDto {
+    private String email;
+}

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/dto/UserProfileResponseDto.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/dto/UserProfileResponseDto.java
@@ -16,6 +16,7 @@ public class UserProfileResponseDto {
     private String nickname;
     private String role;
     private Date registeredAt;
+    private String email;
 
     public static UserProfileResponseDto of(User user) {
         return UserProfileResponseDto.builder()
@@ -24,6 +25,7 @@ public class UserProfileResponseDto {
                 .nickname(user.getNickname())
                 .role(user.getRole().name())
                 .registeredAt(user.getRegisteredAt())
+                .email(user.getEmail())
                 .build();
     }
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/entity/User.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/entity/User.java
@@ -31,6 +31,9 @@ public class User implements UserDetails {
 
     private String nickname;
 
+    @Column(unique = true)
+    private String email;
+
     @Enumerated(EnumType.STRING)
     private Role role; // ADMIN or USER
 

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/repository/UserRepository.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/repository/UserRepository.java
@@ -9,4 +9,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     boolean existsByUsername(String username);
     boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+    Optional<User> findByUsernameAndEmail(String username, String email);
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/domain/user/service/UserService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/domain/user/service/UserService.java
@@ -1,15 +1,14 @@
 package com.kong.kong_dic.domain.user.service;
 
 import com.kong.kong_dic.common.exception.BaseException;
-import com.kong.kong_dic.common.exception.BaseExceptionType;
-import com.kong.kong_dic.domain.user.dto.UserProfileResponseDto;
-import com.kong.kong_dic.domain.user.dto.UserProfileUpdateRequestDto;
-import com.kong.kong_dic.domain.user.dto.UserResponseDto;
-import com.kong.kong_dic.domain.user.dto.UserUpdateRequestDto;
+import com.kong.kong_dic.domain.auth.exception.AuthExceptionType;
+import com.kong.kong_dic.domain.user.dto.*;
 import com.kong.kong_dic.domain.user.entity.User;
 import com.kong.kong_dic.domain.user.exception.UserExceptionType;
 import com.kong.kong_dic.domain.user.repository.UserRepository;
 import com.kong.kong_dic.domain.user.util.NicknameGenerator;
+import com.kong.kong_dic.global.service.RedisService;
+import com.kong.kong_dic.global.service.EmailService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -25,6 +24,11 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RedisService redisService;
+    private final EmailService emailService;
+
+    private static final String EMAIL_VERIFICATION_PREFIX = "EV:";
+    private static final long EMAIL_VERIFICATION_EXPIRATION = 5; // 5 minutes
 
     public UserResponseDto getMyInfo(User user) {
         return UserResponseDto.builder()
@@ -98,6 +102,44 @@ public class UserService {
         }
 
         User updatedUser = userRepository.save(user);
+        return UserProfileResponseDto.of(updatedUser);
+    }
+
+    public void sendVerificationCode(String username, EmailVerificationRequestDto request) throws Exception {
+        userRepository.findByUsername(username)
+                .orElseThrow(() -> new BaseException(UserExceptionType.USER_NOT_FOUND));
+
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BaseException(AuthExceptionType.DUPLICATED_EMAIL);
+        }
+
+        String code = String.format("%06d", new java.util.Random().nextInt(1000000));
+
+        redisService.setData(
+                EMAIL_VERIFICATION_PREFIX + request.getEmail(),
+                code,
+                EMAIL_VERIFICATION_EXPIRATION,
+                java.util.concurrent.TimeUnit.MINUTES
+        );
+
+        emailService.sendVerificationEmail(request.getEmail(), code);
+    }
+
+    @Transactional
+    public UserProfileResponseDto verifyAndRegisterEmail(String username, EmailRegisterRequestDto request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BaseException(UserExceptionType.USER_NOT_FOUND));
+
+        String savedCode = redisService.getData(EMAIL_VERIFICATION_PREFIX + request.getEmail());
+        if (savedCode == null || !savedCode.equals(request.getCode())) {
+            throw new BaseException(AuthExceptionType.INVALID_VERIFICATION_CODE);
+        }
+
+        user.setEmail(request.getEmail());
+        User updatedUser = userRepository.save(user);
+
+        redisService.deleteData(EMAIL_VERIFICATION_PREFIX + request.getEmail());
+
         return UserProfileResponseDto.of(updatedUser);
     }
 }

--- a/kong-dic/src/main/java/com/kong/kong_dic/global/service/EmailService.java
+++ b/kong-dic/src/main/java/com/kong/kong_dic/global/service/EmailService.java
@@ -1,0 +1,83 @@
+package com.kong.kong_dic.global.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    public void sendPasswordResetEmail(String toEmail, String resetLink) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        try {
+            helper.setFrom(fromEmail, "콩국수사전");
+        } catch (java.io.UnsupportedEncodingException e) {
+            helper.setFrom(fromEmail);
+        }
+        helper.setTo(toEmail);
+        helper.setSubject("[콩국수 사전] 비밀번호 재설정 안내");
+
+        String htmlContent = "<div style=\"max-width: 500px; margin: 0 auto; padding: 30px; font-family: 'Malgun Gothic', sans-serif; border: 1px solid #f1ece1; border-radius: 15px; background-color: #fefcf8;\">" +
+                "<h3 style=\"color: #5d4037; font-size: 18px; border-bottom: 2px solid #f7e6c4; padding-bottom: 12px; margin-top: 0;\">안녕하세요, 콩국수 사전입니다.</h3>" +
+                "<p style=\"color: #333; font-size: 14px; line-height: 1.6;\">비밀번호 재설정을 위해 아래 버튼을 클릭해 주세요.</p>" +
+                "<p style=\"color: #e57373; font-size: 12px; font-weight: bold; margin-bottom: 25px;\">※ 이 링크는 발송 후 15분간 유효합니다.</p>" +
+                "<p style=\"text-align: center;\"><a href=\"" + resetLink + "\" target=\"_blank\" style=\"display: inline-block; padding: 12px 30px; background-color: #f7e6c4; color: #5d4037; text-decoration: none; border-radius: 8px; font-weight: bold; font-size: 14px; box-shadow: 0 4px 6px rgba(93,64,55,0.1);\">비밀번호 재설정하러 가기</a></p>" +
+                "<br/>" +
+                "<p style=\"color: #777; font-size: 12px; line-height: 1.5;\">본인이 요청하지 않은 경우, 이 메일을 무시하셔도 안전합니다.</p>" +
+                "<hr style=\"border: 0; border-top: 1px solid #f1ece1; margin: 25px 0;\"/>" +
+                "<p style=\"color: #aaa; font-size: 11px; line-height: 1.4; margin-bottom: 0;\">본 메일은 회원 비밀번호 재설정을 위해 발송된 시스템 자동 메일이며 발신 전용입니다.<br/>" +
+                "© 콩국수 사전. All rights reserved.</p>" +
+                "</div>";
+
+        helper.setText(htmlContent, true);
+
+        mailSender.send(message);
+        log.info("Password reset email sent to {}", toEmail);
+    }
+
+    public void sendVerificationEmail(String toEmail, String code) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        try {
+            helper.setFrom(fromEmail, "콩국수사전");
+        } catch (java.io.UnsupportedEncodingException e) {
+            helper.setFrom(fromEmail);
+        }
+        helper.setTo(toEmail);
+        helper.setSubject("[콩국수 사전] 이메일 인증 번호 안내");
+
+        String htmlContent = "<div style=\"max-width: 500px; margin: 0 auto; padding: 30px; font-family: 'Malgun Gothic', sans-serif; border: 1px solid #f1ece1; border-radius: 15px; background-color: #fefcf8;\">" +
+                "<h3 style=\"color: #5d4037; font-size: 18px; border-bottom: 2px solid #f7e6c4; padding-bottom: 12px; margin-top: 0;\">안녕하세요, 콩국수 사전입니다.</h3>" +
+                "<p style=\"color: #333; font-size: 14px; line-height: 1.6;\">이메일 인증을 위한 6자리 번호는 다음과 같습니다.</p>" +
+                "<div style=\"background-color: #f7e6c4; padding: 15px; border-radius: 10px; text-align: center; margin: 20px 0;\">" +
+                "<span style=\"color: #5d4037; font-size: 24px; font-weight: bold; letter-spacing: 5px;\">" + code + "</span>" +
+                "</div>" +
+                "<p style=\"color: #e57373; font-size: 12px; font-weight: bold; margin-bottom: 25px;\">※ 이 인증번호는 발송 후 5분간 유효합니다.</p>" +
+                "<br/>" +
+                "<p style=\"color: #777; font-size: 12px; line-height: 1.5;\">본인이 요청하지 않은 경우, 이 메일을 무시하셔도 안전합니다.</p>" +
+                "<hr style=\"border: 0; border-top: 1px solid #f1ece1; margin: 25px 0;\"/>" +
+                "<p style=\"color: #aaa; font-size: 11px; line-height: 1.4; margin-bottom: 0;\">본 메일은 회원 이메일 인증을 위해 발송된 시스템 자동 메일이며 발신 전용입니다.<br/>" +
+                "© 콩국수 사전. All rights reserved.</p>" +
+                "</div>";
+
+        helper.setText(htmlContent, true);
+
+        mailSender.send(message);
+        log.info("Verification email sent to {}", toEmail);
+    }
+}

--- a/kongguksu-front/src/App.js
+++ b/kongguksu-front/src/App.js
@@ -13,6 +13,8 @@ import V2RestaurantDetailPage from "./v2/pages/V2RestaurantDetailPage";
 import V2SavedRestaurantsPage from "./v2/pages/V2SavedRestaurantsPage";
 import V2MyPage from "./v2/pages/V2MyPage";
 import V2RankingPage from "./v2/pages/V2RankingPage";
+import V2ForgotPasswordPage from "./v2/pages/V2ForgotPasswordPage";
+import V2ResetPasswordPage from "./v2/pages/V2ResetPasswordPage";
 import { NotificationProvider } from "./v2/contexts/NotificationContext";
 import V2NotificationModal from "./v2/components/V2NotificationModal";
 
@@ -40,6 +42,8 @@ function App() {
           <Route path="/v2/saved" element={<V2SavedRestaurantsPage />} />
           <Route path="/v2/mypage" element={<V2MyPage />} />
           <Route path="/v2/ranking" element={<V2RankingPage />} />
+          <Route path="/v2/forgot-password" element={<V2ForgotPasswordPage />} />
+          <Route path="/reset-password" element={<V2ResetPasswordPage />} />
           
           <Route path="/" element={<MainLayout />}>
             <Route index element={<Navigate to="/v2" replace />} />

--- a/kongguksu-front/src/v2/pages/V2ForgotPasswordPage.jsx
+++ b/kongguksu-front/src/v2/pages/V2ForgotPasswordPage.jsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import axios from 'axios';
+import { toast } from 'react-hot-toast';
+import './V2Main.css';
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080';
+
+const V2ForgotPasswordPage = () => {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const navigate = useNavigate();
+
+  const handleRequestReset = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      const url = `${API_BASE_URL}/auth/reset-password/request`;
+      const response = await axios.post(url, { username, email });
+
+      if (response.data && response.data.code === 0) {
+        toast.success('비밀번호 재설정 이메일이 발송되었습니다.');
+        setSubmitted(true);
+      } else {
+        toast.error(response.data?.message || '이메일 발송에 실패했습니다.');
+      }
+    } catch (error) {
+      toast.error(error.response?.data?.message || '일치하는 사용자 정보를 찾을 수 없거나 서버 통신 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="v2-root bg-background flex flex-col items-center justify-center px-6">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <img src="/images/noodles.png" alt="Logo" className="w-20 h-20 mx-auto mb-4 object-contain animate-bounce-slow" />
+          <h1 className="text-4xl font-black text-primary tracking-tighter font-headline mb-2">
+            비밀번호 찾기
+          </h1>
+          <p className="text-on-surface-variant font-medium">
+            가입할 때 입력하신 아이디와 이메일을 적어주세요.
+          </p>
+        </div>
+
+        {!submitted ? (
+          <form onSubmit={handleRequestReset} className="mt-8 space-y-4">
+            <div className="space-y-2">
+              <label className="text-xs font-bold text-outline uppercase ml-4">아이디</label>
+              <input
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="w-full px-6 py-4 rounded-3xl bg-surface-container border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold placeholder-outline-variant"
+                placeholder="아이디를 입력하세요"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-bold text-outline uppercase ml-4">이메일</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full px-6 py-4 rounded-3xl bg-surface-container border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold placeholder-outline-variant"
+                placeholder="가입 시 등록한 이메일을 입력하세요"
+                required
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-4 mt-6 rounded-3xl bg-primary text-background font-black text-lg soy-shadow active:scale-95 transition-all disabled:opacity-50"
+            >
+              {loading ? '메일 전송 중...' : '재설정 메일 발송'}
+            </button>
+          </form>
+        ) : (
+          <div className="mt-8 p-6 bg-surface-container rounded-3xl text-center space-y-4">
+            <span className="material-symbols-outlined text-secondary text-5xl">mail</span>
+            <p className="text-on-surface font-bold">
+              비밀번호 재설정 메일이 성공적으로 발송되었습니다!
+            </p>
+            <p className="text-xs text-outline font-medium">
+              이메일 보관함을 확인하여 재설정 링크를 클릭해 주십시오.<br/>
+              (링크는 15분간만 유효합니다.)
+            </p>
+            <button
+              onClick={() => navigate('/v2/login')}
+              className="w-full py-3 mt-4 rounded-3xl bg-primary text-background font-black transition-all active:scale-95"
+            >
+              로그인 화면으로
+            </button>
+          </div>
+        )}
+
+        <div className="text-center pt-4">
+          <Link 
+            to="/v2/login" 
+            className="text-secondary font-bold text-sm hover:underline"
+          >
+            로그인 화면으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default V2ForgotPasswordPage;

--- a/kongguksu-front/src/v2/pages/V2LoginPage.jsx
+++ b/kongguksu-front/src/v2/pages/V2LoginPage.jsx
@@ -95,7 +95,7 @@ const V2LoginPage = () => {
           </button>
         </form>
 
-        <div className="text-center pt-4">
+        <div className="text-center pt-4 space-y-2">
           <p className="text-sm text-outline font-medium">
             계정이 없으신가요?{' '}
             <Link 
@@ -103,6 +103,14 @@ const V2LoginPage = () => {
               className="text-secondary font-bold hover:underline"
             >
               회원가입하기
+            </Link>
+          </p>
+          <p className="text-sm">
+            <Link 
+              to="/v2/forgot-password" 
+              className="text-outline hover:text-secondary font-bold text-xs transition-colors"
+            >
+              비밀번호를 분실하셨나요?
             </Link>
           </p>
         </div>

--- a/kongguksu-front/src/v2/pages/V2MyPage.jsx
+++ b/kongguksu-front/src/v2/pages/V2MyPage.jsx
@@ -35,7 +35,15 @@ const V2MyPage = () => {
     nickname: '',
     currentPassword: '',
     newPassword: '',
+    email: '',
   });
+
+  const [emailInput, setEmailInput] = useState('');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [isVerificationSent, setIsVerificationSent] = useState(false);
+  const [isEditingEmail, setIsEditingEmail] = useState(false);
+  const [sendingVerification, setSendingVerification] = useState(false);
+  const [verifyingEmail, setVerifyingEmail] = useState(false);
 
   // Comments state
   const [myComments, setMyComments] = useState([]);
@@ -55,7 +63,14 @@ const V2MyPage = () => {
           ...prev,
           username: userData.username,
           nickname: userData.nickname || '',
+          email: userData.email || '',
         }));
+        setEmailInput(userData.email || '');
+        if (!userData.email) {
+          setIsEditingEmail(true);
+        } else {
+          setIsEditingEmail(false);
+        }
       }
     } catch (err) {
       console.error('Failed to fetch profile:', err);
@@ -117,6 +132,55 @@ const V2MyPage = () => {
   const handleInputChange = (e) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSendVerificationCode = async () => {
+    if (!emailInput || !emailInput.includes('@')) {
+      toast.error('올바른 이메일 주소를 입력해주세요.');
+      return;
+    }
+    setSendingVerification(true);
+    try {
+      const response = await api.post('/users/email/verification-request', { email: emailInput });
+      if (response.data?.code === 0) {
+        toast.success('인증 코드가 이메일로 전송되었습니다.');
+        setIsVerificationSent(true);
+      } else {
+        toast.error(response.data?.message || '인증 코드 발송에 실패했습니다.');
+      }
+    } catch (err) {
+      toast.error(err.response?.data?.message || '이미 등록된 이메일이거나 발송 오류가 발생했습니다.');
+    } finally {
+      setSendingVerification(false);
+    }
+  };
+
+  const handleVerifyAndRegisterEmail = async () => {
+    if (!verificationCode) {
+      toast.error('인증 코드를 입력해주세요.');
+      return;
+    }
+    setVerifyingEmail(true);
+    try {
+      const response = await api.post('/users/email/verify-and-register', {
+        email: emailInput,
+        code: verificationCode
+      });
+      if (response.data?.code === 0) {
+        toast.success('이메일이 성공적으로 등록되었습니다.');
+        const updatedUser = response.data.data;
+        setFormData(prev => ({ ...prev, email: updatedUser.email }));
+        setIsVerificationSent(false);
+        setVerificationCode('');
+        setIsEditingEmail(false);
+      } else {
+        toast.error(response.data?.message || '인증에 실패했습니다.');
+      }
+    } catch (err) {
+      toast.error(err.response?.data?.message || '인증 코드가 유효하지 않거나 만료되었습니다.');
+    } finally {
+      setVerifyingEmail(false);
+    }
   };
 
   const handleRandomNickname = async () => {
@@ -279,6 +343,77 @@ const V2MyPage = () => {
                   className="w-full px-6 py-4 rounded-3xl bg-surface-container text-outline font-bold cursor-not-allowed border-none"
                 />
               </div>
+
+              <div className="space-y-2">
+                <label className="text-xs font-bold text-outline uppercase ml-4">이메일</label>
+                <div className="flex gap-2">
+                  <input
+                    type="email"
+                    value={emailInput}
+                    onChange={(e) => setEmailInput(e.target.value)}
+                    disabled={!isEditingEmail || isVerificationSent}
+                    className={`flex-1 px-6 py-4 rounded-3xl border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold ${
+                      !isEditingEmail ? 'bg-surface-container text-outline cursor-not-allowed' : 'bg-surface-container'
+                    }`}
+                    placeholder="이메일을 입력하세요"
+                    required
+                  />
+                  {!isEditingEmail ? (
+                    <button
+                      type="button"
+                      onClick={() => setIsEditingEmail(true)}
+                      className="px-5 rounded-3xl bg-secondary text-white font-bold text-xs active:scale-95 transition-all"
+                    >
+                      변경
+                    </button>
+                  ) : (
+                    !isVerificationSent && (
+                      <button
+                        type="button"
+                        onClick={handleSendVerificationCode}
+                        disabled={sendingVerification}
+                        className="px-5 rounded-3xl bg-primary text-background font-bold text-xs active:scale-95 transition-all disabled:opacity-50"
+                      >
+                        {sendingVerification ? '전송 중' : '인증 요청'}
+                      </button>
+                    )
+                  )}
+                </div>
+              </div>
+
+              {isEditingEmail && isVerificationSent && (
+                <div className="space-y-2 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                  <label className="text-xs font-bold text-secondary uppercase ml-4">인증 번호 입력</label>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={verificationCode}
+                      onChange={(e) => setVerificationCode(e.target.value)}
+                      className="flex-1 px-6 py-4 rounded-3xl bg-surface-container border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold"
+                      placeholder="6자리 인증 번호를 입력하세요"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={handleVerifyAndRegisterEmail}
+                      disabled={verifyingEmail}
+                      className="px-5 rounded-3xl bg-secondary text-white font-bold text-xs active:scale-95 transition-all disabled:opacity-50"
+                    >
+                      {verifyingEmail ? '확인 중' : '인증 완료'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setIsVerificationSent(false);
+                        setVerificationCode('');
+                      }}
+                      className="px-3 rounded-3xl bg-surface-container-highest text-on-surface-variant font-bold text-xs active:scale-95 transition-all"
+                    >
+                      취소
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <div className="space-y-2">
                 <label className="text-xs font-bold text-outline uppercase ml-4">닉네임</label>

--- a/kongguksu-front/src/v2/pages/V2ResetPasswordPage.jsx
+++ b/kongguksu-front/src/v2/pages/V2ResetPasswordPage.jsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
+import axios from 'axios';
+import { toast } from 'react-hot-toast';
+import './V2Main.css';
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080';
+
+const V2ResetPasswordPage = () => {
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // URL에서 token 쿼리 매개변수 추출
+  const searchParams = new URLSearchParams(location.search);
+  const token = searchParams.get('token');
+
+  const handleResetPassword = async (e) => {
+    e.preventDefault();
+
+    if (!token) {
+      toast.error('유효하지 않은 접근입니다. 토큰이 존재하지 않습니다.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      toast.error('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const url = `${API_BASE_URL}/auth/reset-password/confirm`;
+      const response = await axios.post(url, {
+        token,
+        newPassword
+      });
+
+      if (response.data && response.data.code === 0) {
+        toast.success('비밀번호가 성공적으로 변경되었습니다. 다시 로그인해주세요!');
+        navigate('/v2/login');
+      } else {
+        toast.error(response.data?.message || '비밀번호 변경에 실패했습니다.');
+      }
+    } catch (error) {
+      toast.error(error.response?.data?.message || '토큰이 만료되었거나 올바르지 않습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="v2-root bg-background flex flex-col items-center justify-center px-6">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <img src="/images/noodles.png" alt="Logo" className="w-20 h-20 mx-auto mb-4 object-contain animate-bounce-slow" />
+          <h1 className="text-4xl font-black text-primary tracking-tighter font-headline mb-2">
+            새 비밀번호 설정
+          </h1>
+          <p className="text-on-surface-variant font-medium">
+            새로 변경할 비밀번호를 입력해 주십시오.
+          </p>
+        </div>
+
+        {!token ? (
+          <div className="mt-8 p-6 bg-surface-container rounded-3xl text-center space-y-4">
+            <span className="material-symbols-outlined text-error text-5xl">warning</span>
+            <p className="text-on-surface font-bold text-error">
+              유효하지 않거나 잘못된 접근입니다.
+            </p>
+            <p className="text-xs text-outline font-medium">
+              비밀번호 재설정 메일의 링크를 다시 확인하시거나, 재설정 요청을 새로 해주십시오.
+            </p>
+            <button
+              onClick={() => navigate('/v2/forgot-password')}
+              className="w-full py-3 mt-4 rounded-3xl bg-primary text-background font-black transition-all active:scale-95"
+            >
+              재설정 메일 요청하러 가기
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleResetPassword} className="mt-8 space-y-4">
+            <div className="space-y-2">
+              <label className="text-xs font-bold text-outline uppercase ml-4">새 비밀번호</label>
+              <input
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="w-full px-6 py-4 rounded-3xl bg-surface-container border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold placeholder-outline-variant"
+                placeholder="새 비밀번호를 입력하세요"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-bold text-outline uppercase ml-4">비밀번호 확인</label>
+              <input
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full px-6 py-4 rounded-3xl bg-surface-container border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold placeholder-outline-variant"
+                placeholder="비밀번호를 한번 더 입력하세요"
+                required
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-4 mt-6 rounded-3xl bg-primary text-background font-black text-lg soy-shadow active:scale-95 transition-all disabled:opacity-50"
+            >
+              {loading ? '변경 중...' : '비밀번호 변경 완료'}
+            </button>
+          </form>
+        )}
+
+        <div className="text-center pt-4">
+          <Link 
+            to="/v2/login" 
+            className="text-secondary font-bold text-sm hover:underline"
+          >
+            로그인 화면으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default V2ResetPasswordPage;

--- a/kongguksu-front/src/v2/pages/V2SignupPage.jsx
+++ b/kongguksu-front/src/v2/pages/V2SignupPage.jsx
@@ -12,6 +12,7 @@ const V2SignupPage = () => {
     username: '',
     nickname: '',
     password: '',
+    email: '',
   });
   const [loading, setLoading] = useState(false);
   const [isGeneratingNickname, setIsGeneratingNickname] = useState(false);
@@ -56,6 +57,7 @@ const V2SignupPage = () => {
         username: formData.username,
         password: formData.password,
         nickname: formData.nickname,
+        email: formData.email,
       });
 
       if (response.data && response.data.code === 0) {
@@ -117,6 +119,19 @@ const V2SignupPage = () => {
                 {isGeneratingNickname ? '생성 중...' : '랜덤 생성'}
               </button>
             </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-bold text-outline uppercase ml-4">이메일</label>
+            <input
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="w-full px-6 py-4 rounded-3xl bg-surface-container border-none focus:ring-2 focus:ring-secondary text-on-surface font-bold placeholder-outline-variant transition-all"
+              placeholder="이메일을 입력하세요 (비밀번호 분실 시 필요)"
+              required
+            />
           </div>
 
           <div className="space-y-2">


### PR DESCRIPTION
## 📝 작업 배경 (Background)

사용자가 비밀번호를 분실했을 때 이메일을 통해 재설정할 수 있는 계정 복구(Recover) 수단을 제공하고, 마이페이지에서 이메일을 등록 및 인증할 수 있도록 지원하여 전반적인 사용자 보안 및 편의성을 높이고자 합니다.

## 🛠️ 주요 변경 내역 (Changes)

### ☕ Backend

- **이메일 전송 기능 구현**: `spring-boot-starter-mail` 의존성을 추가하고, JavaMailSender 기반의 공통 `EmailService`를 구현했습니다.
- **Redis를 활용한 임시 인증 정보 및 세션 관리**:
  - **비밀번호 재설정 토큰**: 생성한 재설정 토큰(`PR:{UUID}`)을 Redis에 키로 저장하고, 해당 사용자(`username`) 정보를 만료 시간 15분(TTL)과 함께 보관합니다. 재설정 완료 시 즉시 삭제됩니다.
  - **이메일 인증 코드**: 발송된 6자리 인증 번호(`EV:{Email}`)를 Redis에 저장하고 5분(TTL) 만료 시간을 적용하여 검증 후 이메일 등록이 성공하면 즉시 삭제됩니다.
- **비밀번호 재설정 API**: 비밀번호 재설정 메일 발송 요청(`POST /api/auth/reset-password/request`) 및 토큰 기반 비밀번호 변경 확인(`POST /api/auth/reset-password/confirm`) API를 작성했습니다.
- **마이페이지 이메일 등록 API**: 로그인한 사용자가 본인의 이메일을 등록하고 인증할 수 있도록 인증코드 발송(`POST /api/users/email/verification-request`) 및 코드 검증/등록(`POST /api/users/email/verify-and-register`) API를 구현했습니다.
- **도메인 모델 갱신**: `User` 엔티티에 `email` 필드를 추가하고, 회원가입 DTO 및 프로필 응답 DTO에 반영했습니다.

### 🎨 Frontend

- **회원가입/로그인 연동**: 회원가입 시 이메일 입력을 추가하고, 로그인 페이지에서 "비밀번호 찾기" 링크를 추가했습니다.
- **이메일 인증 UI 구현**: 마이페이지(`V2MyPage`)에서 이메일을 입력하고 인증번호를 전송 및 검증하여 계정에 이메일을 연동하는 UI를 구현했습니다.
- **비밀번호 재설정 페이지 추가**: 비밀번호 찾기(이메일 입력)를 수행하는 `V2ForgotPasswordPage`와 메일의 토큰 링크를 통해 새 비밀번호를 입력하는 `V2ResetPasswordPage`를 구현하고, `App.js`에 라우팅을 등록했습니다.

## 📋 테스트 결과 (Test Results)

- 회원가입 시 이메일 필드가 정상적으로 데이터베이스에 저장되는지 확인했습니다.
- 마이페이지에서 이메일 인증 코드가 전송되고, 올바른 코드를 넣었을 때 이메일이 연동/등록되는 것을 검증했습니다.
- 비밀번호 재설정 요청 후 발송된 이메일 링크를 통해 토큰을 검증하고, 새 비밀번호로의 갱신이 원활히 동작하는지 확인했습니다.
- Redis 내 인증키 및 토큰들이 지정된 TTL 만료 시점에 정상 삭제되며, 검증 성공 후에도 정상 파기됨을 확인했습니다.